### PR TITLE
Fixed Country#nationalities from producing duplications, added some specs

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -101,23 +101,32 @@ class ISO3166::Country
 
     def all_translated(locale = "en")
       translate = ->(country) { self.new(country[1]).translations[locale] }
-      list = self.all.map(&translate).compact.sort
+      self.all.map(&translate).compact.sort
     end
 
     def nationalities(locale = "en")
       translate = ->(country) do
-        loc_locale = self[country[1]].nationality_translations[locale].blank? ? "en" : locale
+        local_locale = locale.to_s.downcase
 
-        nationality_translation = self[country[1]].nationality_translations[loc_locale]
-        next if nationality_translation.blank?
+        country_translations = self[country[1]].translations
+        country_nationality_translations = self[country[1]].nationality_translations
 
-        if EXCEPTIONS.include?(country[1])
-          ["#{nationality_translation} (#{self[country[1]].translations[loc_locale]})", country[1]]
+        nationality_translation = country_nationality_translations[local_locale]
+
+        if nationality_translation.to_s.empty?
+          local_locale = "en"
+          nationality_translation = country_nationality_translations["en"]
+        end
+        return if nationality_translation.to_s.empty?
+
+        if EXCEPTIONS.include?(country[1]) && country_translations[local_locale]
+          ["#{nationality_translation} (#{country_translations[local_locale]})", country[1]]
         else
           [nationality_translation, country[1]]
         end
       end
-      list = self.all.map(&translate).compact.uniq.sort
+
+      self.all.map(&translate).compact.uniq.sort
     end
 
     def search(query)

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -371,6 +371,7 @@ AN:
     en: Dutch
     de: Niederländisch
     at: Niederländisch
+    nl: Nederlands
   dissolved_on: '2010-10-10'
   postal_code: false
 AO:
@@ -1417,8 +1418,9 @@ BQ:
     de: Bonaire, Sint Eustatius und Saba
     at: Bonaire, Sint Eustatius und Saba
     fr: Pays-Bas caribéens
-    ru: Бонэйр, Синт-Эстатиус и Саба
     ja: ボネール、シント・ユースタティウスおよびサバ
+    nl: Bonaire, Sint Eustatius en Saba
+    ru: Бонэйр, Синт-Эстатиус и Саба
   national_destination_code_lengths:
   - 2
   national_number_lengths:
@@ -1436,6 +1438,7 @@ BQ:
     en: Dutch
     de: Niederländisch
     at: Niederländisch
+    nl: Nederlands
   postal_code: true
 BR:
   continent: South America
@@ -2487,6 +2490,7 @@ CW:
     en: Dutch
     de: Niederländisch
     at: Niederländisch
+    nl: Nederlands
   postal_code: true
 CX:
   continent: Asia
@@ -8005,7 +8009,7 @@ NZ:
   national_number_lengths:
   - 8
   - 9
-  national_prefix: 0 (None fo
+  national_prefix: '0'
   number: '554'
   region: Oceania
   subregion: Australia and New Zealand
@@ -9897,6 +9901,7 @@ SX:
     en: Dutch
     de: Niederländisch
     at: Niederländisch
+    nl: Nederlands
   postal_code: true
 SY:
   continent: Asia

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -187,6 +187,24 @@ describe ISO3166::Country do
     end
   end
 
+  describe '#nationalities' do
+    it 'should provide the same translation for passed symbol or string' do
+      ISO3166::Country.nationalities(:de).should == ISO3166::Country.nationalities("de")
+    end
+
+    it 'should provide the same translation for passed up-cased or down-cased locale' do
+      ISO3166::Country.nationalities("DE").should == ISO3166::Country.nationalities("de")
+    end
+
+    it 'should fallback to default :en translation if passed is wrong' do
+      ISO3166::Country.nationalities("lang").should == ISO3166::Country.nationalities("en")
+    end
+
+    it 'should provide country for exceptions' do
+      ISO3166::Country.nationalities("nl").find { |item| item[1] == "NL" }[0].should == "Nederlands (Nederland)"
+    end
+  end
+
   describe 'countries' do
     it 'should be the same as all' do
       ISO3166::Country.countries.should == ISO3166::Country.all


### PR DESCRIPTION
### Issue
https://trello.com/c/hINh4LGh/513-some-customers-still-have-the-nation-several-times-behind-their-nationality-in-their-applications-so-it-says-nederlands-nederlan

### Changes
* Transform passed locale to string and make it down-cased always.
* Optimised `#nationalities` method code.
* Added simple specs.